### PR TITLE
MELOSYS-3255 - Oppdaterer beskrivelsen for koden BOSATT_I_NORGE

### DIFF
--- a/src/begrunnelser/unntak_periode_begrunnelser.js
+++ b/src/begrunnelser/unntak_periode_begrunnelser.js
@@ -38,7 +38,7 @@ const unntak_periode_begrunnelser = [
   },
   {
     kode: 'BOSATT_I_NORGE',
-    term: 'Person er bosatt i Norge'
+    term: 'Personen har en folkeregistrert adresse i Norge'
   },
   {
     kode: 'INGEN_SLUTTDATO',


### PR DESCRIPTION
**Fra Jira:**
Gjelder behandling av innkomne SED A009 og A001 og treff ved automatisk kontroll. Dersom personen har en folkeregistrert adresse i TPS, kommer følgende beskrivelse opp: 
Det hadde vært mer presist om det stod: "Personen har en folkeregistrert adresse i Norge". 