### PR TITLE
Oppdater melosys-kodeverk-java

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
     docker:
       # Henter inn docker-image for melosys-kodeverk-java, som kan generere melosys-internt-kodeverk
       # Bruker eksplisitt referanse, og ikke latest (siden det verken garanterer bygg som kan rekjøres, eller at det faktisk er siste versjon)
-      - image: navikt/melosys-kodeverk-java:078bc2fd1eececc31889cc44c0f34f2f806c3aba
+      - image: navikt/melosys-kodeverk-java:002e2a7b2e5bbb236e71835fbb1e9d6250391a80
 
 jobs:
   bygge_frontend:


### PR DESCRIPTION
Oppdaterer til ny melosys-kodeverk-java som støtter overgangsregelbestemmelser