### PR TITLE
Nye begrunnelse-kodeverk for medfølgende familie i FTLR

### DIFF
--- a/schema/kodeverk-schema.json
+++ b/schema/kodeverk-schema.json
@@ -202,7 +202,9 @@
             "endret_unntaksperiode",
             "ftrl_2_8_forutgaaende_trygdetid_begrunnelser",
             "ftrl_2_8_naer_tilknytning_norge_begrunnelser",
-            "avslag"
+            "avslag",
+            "medfolgende_barn_begrunnelser_ftrl",
+            "medfolgende_ektefelle_samboer_begrunnelser_ftrl"
           ],
           "properties": {
             "endret_unntaksperiode": {
@@ -215,6 +217,12 @@
               "$ref": "#/definitions/kodeverkArray"
             },
             "avslag": {
+              "$ref": "#/definitions/kodeverkArray"
+            },
+            "medfolgende_barn_begrunnelser_ftrl": {
+              "$ref": "#/definitions/kodeverkArray"
+            },
+            "medfolgende_ektefelle_samboer_begrunnelser_ftrl": {
               "$ref": "#/definitions/kodeverkArray"
             }
           }

--- a/src/begrunnelser/folketrygdloven/index.js
+++ b/src/begrunnelser/folketrygdloven/index.js
@@ -2,12 +2,16 @@ const { avslag } = require('./avslag');
 const { endret_unntaksperiode } = require('./endretunntaksperiode');
 const { ftrl_2_8_forutgaaende_trygdetid_begrunnelser } = require('./ftrl_2_8_forutgaaende_trygdetid_begrunnelser');
 const { ftrl_2_8_naer_tilknytning_norge_begrunnelser } = require('./ftrl_2_8_naer_tilknytning_norge_begrunnelser');
+const { medfolgende_barn_begrunnelser_ftrl } = require('./medfolgende_barn_begrunnelser_ftrl');
+const { medfolgende_ektefelle_samboer_begrunnelser_ftrl } = require('./medfolgende_ektefelle_samboer_begrunnelser_ftrl');
 
 const folketrygdloven = {
   avslag,
   endret_unntaksperiode,
   ftrl_2_8_forutgaaende_trygdetid_begrunnelser,
-  ftrl_2_8_naer_tilknytning_norge_begrunnelser
+  ftrl_2_8_naer_tilknytning_norge_begrunnelser,
+  medfolgende_barn_begrunnelser_ftrl,
+  medfolgende_ektefelle_samboer_begrunnelser_ftrl
 };
 
 module.exports.folketrygdloven = folketrygdloven;

--- a/src/begrunnelser/folketrygdloven/medfolgende_barn_begrunnelser_ftrl.js
+++ b/src/begrunnelser/folketrygdloven/medfolgende_barn_begrunnelser_ftrl.js
@@ -1,0 +1,20 @@
+/**
+ * Kodeverk/medfolgende_barn_begrunnelser_ftrl
+ * ref: https://confluence.adeo.no/display/TEESSI/Ulike+begrunnelser+FTRL#UlikebegrunnelserFTRL-MEDF%C3%98LGENDE_BARN_BEGRUNNELSER_FTRL
+ * @module
+ */
+const medfolgende_barn_begrunnelser_ftrl = [
+  {
+    kode: 'OVER_18_AR',
+    term: 'Personen det søkes for er over 18 år'
+  },
+  {
+    kode: 'IKKE_SOEKERS_BARN',
+    term: 'Barnet er ikke søkerens eget'
+  },
+  {
+    kode: 'MANGLER_OPPLYSNINGER',
+    term: 'Mangler opplysninger for å vurdere barnets trygdetilhørighet'
+  }
+];
+module.exports.medfolgende_barn_begrunnelser_ftrl = medfolgende_barn_begrunnelser_ftrl;

--- a/src/begrunnelser/folketrygdloven/medfolgende_ektefelle_samboer_begrunnelser_ftrl.js
+++ b/src/begrunnelser/folketrygdloven/medfolgende_ektefelle_samboer_begrunnelser_ftrl.js
@@ -1,0 +1,24 @@
+/**
+ * Kodeverk/medfolgende_ektefelle_samboer_begrunnelser_ftrl
+ * ref: https://confluence.adeo.no/display/TEESSI/Ulike+begrunnelser+FTRL#UlikebegrunnelserFTRL-MEDF%C3%98LGENDE_EKTEFELLE_SAMBOER_BEGRUNNELSER_FTRL
+ * @module
+ */
+const medfolgende_ektefelle_samboer_begrunnelser_ftrl = [
+  {
+    kode: 'SAMBOER_UTEN_FELLES_BARN',
+    term: 'Samboer uten felles barn'
+  },
+  {
+    kode: 'EGEN_INNTEKT',
+    term: 'Ektefelle/samboer har egen inntekt'
+  },
+  {
+    kode: 'IKKE_TRE_AV_FEM',
+    term: 'Ektefelle/samboer har ikke vært medlem i tre av de siste fem kalenderårene'
+  },
+  {
+    kode: 'MANGLER_OPPLYSNINGER',
+    term: 'Mangler opplysninger for å vurdere ektefelle/samboers trygdetilhørighet'
+  }
+];
+module.exports.medfolgende_ektefelle_samboer_begrunnelser_ftrl = medfolgende_ektefelle_samboer_begrunnelser_ftrl;


### PR DESCRIPTION
Nye kodeverk til bruk i familie-steget for FTLR: [MELOSYS-4213](https://jira.adeo.no/browse/MELOSYS-4213)
Confluence til de to kodeverkene: 
- [medfolgende_barn_begrunnelser_ftrl](https://confluence.adeo.no/display/TEESSI/Ulike+begrunnelser+FTRL#UlikebegrunnelserFTRL-MEDF%C3%98LGENDE_BARN_BEGRUNNELSER_FTRL)
- [medfolgende_ektefelle_samboer_begrunnelser_ftrl](https://confluence.adeo.no/display/TEESSI/Ulike+begrunnelser+FTRL#UlikebegrunnelserFTRL-MEDF%C3%98LGENDE_EKTEFELLE_SAMBOER_BEGRUNNELSER_FTRL)