### PR TITLE
Lagt til nytt kodeverk Avtaleland

### DIFF
--- a/melosys-kodeverk-java/melosys-kodeverk-generator/src/test/resources/dist/kodemap.yml
+++ b/melosys-kodeverk-java/melosys-kodeverk-generator/src/test/resources/dist/kodemap.yml
@@ -39,6 +39,35 @@ avklartefaktatyper:
     term: null
   - kode: ARBEIDSGIVERS_FORRETNINGSSTED
     term: null
+avtaleland:
+  - kode: AU
+    term: Australia
+  - kode: BA
+    term: Bosnia-Hercegovina
+  - kode: CA
+    term: Canada
+  - kode: CL
+    term: Chile
+  - kode: IN
+    term: India
+  - kode: IL
+    term: Israel
+  - kode: ME
+    term: Montenegro
+  - kode: RS
+    term: Serbia
+  - kode: GB
+    term: Storbritannia
+  - kode: JE
+    term: Jersey
+  - kode: IM
+    term: Isle of Man
+  - kode: TR
+    term: Tyrkia
+  - kode: US
+    term: USA
+  - kode: CH
+    term: Sveits
 behandlinger:
   behandlingsresultattyper:
     - kode: FASTSATT_LOVVALGSLAND

--- a/schema/kodeverk-schema.json
+++ b/schema/kodeverk-schema.json
@@ -54,6 +54,7 @@
     "anmodningsperiodesvartyper",
     "avklartefaktatyper",
     "avsendertyper",
+    "avtaleland",
     "behandlinger",
     "begrunnelser",
     "brev",
@@ -89,6 +90,9 @@
       "$ref": "#/definitions/kodeverkArray"
     },
     "avsendertyper": {
+      "$ref": "#/definitions/kodeverkArray"
+    },
+    "avtaleland": {
       "$ref": "#/definitions/kodeverkArray"
     },
     "behandlinger": {

--- a/src/avtaleland.js
+++ b/src/avtaleland.js
@@ -1,0 +1,63 @@
+/**
+ * Kodeverk/avtaleland
+ * @module
+ */
+const avtaleland = [
+  {
+    kode: 'AU',
+    term: 'Australia',
+  },
+  {
+    kode: 'BA',
+    term: 'Bosnia-Hercegovina',
+  },
+  {
+    kode: 'CA',
+    term: 'Canada',
+  },
+  {
+    kode: 'CL',
+    term: 'Chile',
+  },
+  {
+    kode: 'IN',
+    term: 'India',
+  },
+  {
+    kode: 'IL',
+    term: 'Israel',
+  },
+  {
+    kode: 'ME',
+    term: 'Montenegro',
+  },
+  {
+    kode: 'RS',
+    term: 'Serbia',
+  },
+  {
+    kode: 'GB',
+    term: 'Storbritannia',
+  },
+  {
+    kode: 'JE',
+    term: 'Jersey'
+  },
+  {
+    kode: 'IM',
+    term: 'Isle of Man'
+  },
+  {
+    kode: 'TR',
+    term: 'Tyrkia',
+  },
+  {
+    kode: 'US',
+    term: 'USA',
+  },
+  {
+    kode: 'CH',
+    term: 'Sveits',
+  },
+];
+module.exports.avtaleland = avtaleland;

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const { aktoersroller } = require('./aktoerroller');
 const { anmodningsperiodesvartyper } = require('./anmodningsperiodesvartyper');
 const { avklartefaktatyper } = require('./avklartefaktatyper');
 const { avsendertyper } = require('./avsendertyper');
+const { avtaleland } = require('./avtaleland');
 const { begrunnelser } = require('./begrunnelser');
 const { behandlinger } = require('./behandlinger');
 const { behandlingsgrunnlagtyper } = require('./behandlingsgrunnlagtyper.js');
@@ -45,6 +46,7 @@ const KodeTermObjects = {
   anmodningsperiodesvartyper,
   avklartefaktatyper,
   avsendertyper,
+  avtaleland,
   behandlinger,
   behandlingsgrunnlagtyper,
   begrunnelser,


### PR DESCRIPTION
Basert på https://confluence.adeo.no/display/TEESSI/Avtaleland

Quebec ligger under Canada
Storbritanniaavtalen omfatter også Jersey og Isle of Man