### PR TITLE
Nytt lovvalgbestemmelser_trygdeavtale_uk kodeverk

### DIFF
--- a/melosys-kodeverk-java/melosys-kodeverk-generator/src/main/resources/application.yml
+++ b/melosys-kodeverk-java/melosys-kodeverk-generator/src/main/resources/application.yml
@@ -22,5 +22,6 @@ generator:
     - Lovvalgbestemmelser_987_2009
     - Tilleggsbestemmelser_883_2004
     - Overgangsregelbestemmelser
+    - Lovvalgbestemmelser_trygdeavtale_uk
   pakke-navn: no.nav.melosys.domain.kodeverk
 

--- a/schema/kodeverk-schema.json
+++ b/schema/kodeverk-schema.json
@@ -305,7 +305,8 @@
       "required": [
         "lovvalgbestemmelser_883_2004",
         "lovvalgbestemmelser_987_2009",
-        "tilleggsbestemmelser_883_2004"
+        "tilleggsbestemmelser_883_2004",
+        "lovvalgbestemmelser_trygdeavtale_uk"
       ],
       "properties": {
         "lovvalgbestemmelser_883_2004": {
@@ -318,6 +319,9 @@
           "$ref": "#/definitions/kodeverkArray"
         },
         "overgangsregelbestemmelser": {
+          "$ref": "#/definitions/kodeverkArray"
+        },
+        "lovvalgbestemmelser_trygdeavtale_uk": {
           "$ref": "#/definitions/kodeverkArray"
         }
       }

--- a/src/lovvalgsbestemmelser/index.js
+++ b/src/lovvalgsbestemmelser/index.js
@@ -2,11 +2,13 @@ const { lovvalgbestemmelser_883_2004 } = require('./lovvalgbestemmelser_883_2004
 const { lovvalgbestemmelser_987_2009 } = require('./lovvalgbestemmelser_987_2009');
 const { tilleggsbestemmelser_883_2004 } = require('./tilleggsbestemmelser_883_2004');
 const { overgangsregelbestemmelser } = require('./overgangsregelbestemmelser');
+const { lovvalgbestemmelser_trygdeavtale_uk } = require('./lovvalgbestemmelser_trygdeavtale_uk');
 
 const lovvalgsbestemmelser = {
   lovvalgbestemmelser_883_2004,
   lovvalgbestemmelser_987_2009,
   tilleggsbestemmelser_883_2004,
   overgangsregelbestemmelser,
+  lovvalgbestemmelser_trygdeavtale_uk,
 };
 module.exports.lovvalgsbestemmelser = lovvalgsbestemmelser;

--- a/src/lovvalgsbestemmelser/lovvalgbestemmelser_trygdeavtale_uk.js
+++ b/src/lovvalgsbestemmelser/lovvalgbestemmelser_trygdeavtale_uk.js
@@ -1,0 +1,23 @@
+const lovvalgbestemmelser_trygdeavtale_uk = [
+  {
+    kode: 'UK_ART6_1',
+    term: 'Utsendt arbeidstaker - artikkel 6 nr. 1',
+  },
+  {
+    kode: 'UK_ART6_5',
+    term: 'Utsendt til kontinentalsokkel - artikkel 6 nr. 5',
+  },
+  {
+    kode: 'UK_ART7',
+    term: 'Arbeid på skip - artikkel 7',
+  },
+  {
+    kode: 'UK_ART8_2',
+    term: 'Offentlig tjenesteperson - artikkel 8 nr. 2',
+  },
+  {
+    kode: 'UK_ART9',
+    term: 'Innvilgelse unntak - artikkel 9',
+  }
+];
+module.exports.lovvalgbestemmelser_trygdeavtale_uk = lovvalgbestemmelser_trygdeavtale_uk;


### PR DESCRIPTION
Valgte å legge det under generell (tidligere kun EU_EØS) **Lovvalsbestemmelser**-mappen siden det heter `lovvalgbestemmelser_trygdeavtale_uk`, men kan flytte det ut om det blir mer naturlig 🤔 