### PR TITLE
MELOSYS-4815: Nye behandlingsresultater

### DIFF
--- a/src/behandlinger/behandlingsresultattyper.js
+++ b/src/behandlinger/behandlingsresultattyper.js
@@ -14,7 +14,7 @@ const behandlingsresultattyper = [
   },
   {
     kode: 'HENLEGGELSE',
-    term: 'Behandlingen er henlagt/trukket',
+    term: 'Søknaden er henlagt/trukket',
   },
   {
     kode: 'ANMODNING_OM_UNNTAK',
@@ -38,7 +38,7 @@ const behandlingsresultattyper = [
   },
   {
     kode: 'AVSLUTTET_UTEN_ENDRING',
-    term: 'Ferdigbehandlet'
+    term: 'Ferdigbehandlet uten nytt vedtak'
   },
   {
     kode: 'HENLEGGELSE_BORTFALT',

--- a/src/behandlinger/behandlingsresultattyper.js
+++ b/src/behandlinger/behandlingsresultattyper.js
@@ -38,7 +38,7 @@ const behandlingsresultattyper = [
   },
   {
     kode: 'AVSLUTTET_UTEN_ENDRING',
-    term: 'Ferdigbehandlet uten nytt vedtak'
+    term: 'Behandlingen er avsluttet'
   },
   {
     kode: 'HENLEGGELSE_BORTFALT',

--- a/src/behandlinger/behandlingsresultattyper.js
+++ b/src/behandlinger/behandlingsresultattyper.js
@@ -14,7 +14,7 @@ const behandlingsresultattyper = [
   },
   {
     kode: 'HENLEGGELSE',
-    term: 'Saken er henlagt',
+    term: 'Behandlingen er henlagt/trukket',
   },
   {
     kode: 'ANMODNING_OM_UNNTAK',

--- a/src/behandlinger/behandlingsresultattyper.js
+++ b/src/behandlinger/behandlingsresultattyper.js
@@ -37,8 +37,8 @@ const behandlingsresultattyper = [
     term: 'Medlem i folketrygden'
   },
   {
-    kode: 'AVSLUTTET_UTEN_ENDRING',
-    term: 'Ferdigbehandlet uten nytt vedtak'
+    kode: 'FERDIGBEHANDLET',
+    term: 'Ferdigbehandlet'
   },
   {
     kode: 'HENLEGGELSE_BORTFALT',

--- a/src/behandlinger/behandlingsresultattyper.js
+++ b/src/behandlinger/behandlingsresultattyper.js
@@ -38,7 +38,7 @@ const behandlingsresultattyper = [
   },
   {
     kode: 'AVSLUTTET_UTEN_ENDRING',
-    term: 'Behandlingen er avsluttet'
+    term: 'Ferdigbehandlet uten nytt vedtak'
   },
   {
     kode: 'HENLEGGELSE_BORTFALT',

--- a/src/behandlinger/behandlingsresultattyper.js
+++ b/src/behandlinger/behandlingsresultattyper.js
@@ -35,6 +35,14 @@ const behandlingsresultattyper = [
   {
     kode: 'MEDLEM_I_FOLKETRYGDEN',
     term: 'Medlem i folketrygden'
+  },
+  {
+    kode: 'AVSLUTTET_UTEN_ENDRING',
+    term: 'Ferdigbehandlet'
+  },
+  {
+    kode: 'HENLEGGELSE_BORTFALT',
+    term: 'Kan ikke behandles i Melosys'
   }
 ];
 module.exports.behandlingsresultattyper = behandlingsresultattyper;


### PR DESCRIPTION
Dette legger til og endrer på behandlingsresultater.

Behandlingsresultatet "HENLEGGELSE" er ikke ny og har endret term. Når denne merges inn i master, vil den potensielt også prodsettes i API før testing av MELOSYS-4815 er ferdig. Dette har jeg avklart med fag, og den endringen er ok.