### PR TITLE
Byttet navn til mer bekskrivende

### DIFF
--- a/src/aktoerroller.js
+++ b/src/aktoerroller.js
@@ -17,7 +17,7 @@ const aktoersroller = [
     term: 'Fullmektig'
   },
   {
-    kode: 'MYNDIGHET',
+    kode: 'TRYGDEMYNDIGHET',
     term: 'Trygdemyndighet'
   },
   {


### PR DESCRIPTION
Aktoersrolle MYNDIGHET er mer riktig som TRYGDEMYNDIGHET (som termet allerede var)