### PR TITLE
Endringer i kodeverket nyvurderingbakgrunner

### DIFF
--- a/src/begrunnelser/nyvurderingbakgrunner.js
+++ b/src/begrunnelser/nyvurderingbakgrunner.js
@@ -5,16 +5,12 @@
  */
 const nyvurderingbakgrunner = [
   {
-    kode: 'SAKSBEHANDLER_OPPDAGET_FEIL',
-    term: 'Saksbehandler oppdaget feil'
+    kode: 'FEIL_I_BEHANDLING',
+    term: 'Det ble gjort feil i tidligere behandling'
   },
   {
-    kode: 'HENVENDELSE_OM_OPPDAGET_FEIL',
-    term: 'Mottatt henvendelse om oppdaget feil'
-  },
-  {
-    kode: 'HENVENDELSE_OM_FEIL_BRUKER',
-    term: 'Bruker har meldt fra om feil'
+    kode: 'NYE_OPPLYSNINGER',
+    term: 'Det er mottatt nye opplysninger i saken'
   }
 ];
 


### PR DESCRIPTION
De 3 gamle kodene blir erstattet med den nye mer generelle koden "Det ble gjort feil i tidligere behandling". I tillegg kommer det ny kode: NYE_OPPLYSNINGER. 

https://jira.adeo.no/browse/MELOSYS-4818

https://confluence.adeo.no/display/TEESSI/Kodeverk+i+Melosys#KodeverkiMelosys-NyVurderingBakgrunn