### PR TITLE
Ny kontrollBegrunnelse for ikke én arbeidgiver

### DIFF
--- a/src/begrunnelser/kontroll_begrunnelser.js
+++ b/src/begrunnelser/kontroll_begrunnelser.js
@@ -85,6 +85,10 @@ const kontroll_begrunnelser = [
     term: 'Du må oppgi et arbeidssted/representant i utlandet'
   },
   {
+    kode: 'IKKE_ÉN_VIRKSOMHET',
+    term: 'Ingen eller flere enn én norsk eller utenlandsk virksomhet oppgitt for avslag eller art 16.1'
+  },
+  {
     kode: 'ANNET',
     term: 'Fritekstfelt'
   }


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5067
Legger til validering på `antallArbeidsgivere != 1`, derfor ny kode i kodeverk.