### PR TITLE
Legger til GENERELT_FRITEKSTBREV_VIRKSOMHET

### DIFF
--- a/src/brev/produserbaredokumenter.js
+++ b/src/brev/produserbaredokumenter.js
@@ -101,6 +101,10 @@ const produserbaredokumenter = [
   {
     kode: 'GENERELT_FRITEKSTBREV_ARBEIDSGIVER',
     term: 'Fritekstbrev til virksomhet'
+  },
+  {
+    kode: 'GENERELT_FRITEKSTBREV_VIRKSOMHET',
+    term: 'Fritekstbrev til virksomhet'
   }
 ];
 


### PR DESCRIPTION
Ser nytten i å lage nytt produserbart dokument. Mens beskrivelsen på GENERELT_FRITEKSTBREV_ARBEIDSGIVER passer til virksomhet, så er all logikk i brevtjenesten vår basert på ARBEIDSGIVERen og ikke VIRKSOMHET som hoved-aktør. 

Istedenfor å skrive om slik at GENERELT_FRITEKSTBREV_ARBEIDSGIVER støtter både arbeidsgiver og virksomhet, legger jeg til GENERELT_FRITEKSTBREV_VIRKSOMHET for å klargjøre forskjellene.

https://jira.adeo.no/browse/MELOSYS-5127