### PR TITLE
5094: Feilmelding for manglende adresse er gjort mer generell

### DIFF
--- a/src/begrunnelser/kontroll_begrunnelser.js
+++ b/src/begrunnelser/kontroll_begrunnelser.js
@@ -89,6 +89,10 @@ const kontroll_begrunnelser = [
     term: 'Ingen eller flere enn én norsk eller utenlandsk virksomhet oppgitt for avslag eller art 16.1'
   },
   {
+    kode: 'INGEN_ARBEIDSGIVERE',
+    term: 'Finner ingen arbeidsgivere. Hent registeropplysninger'
+  },
+  {
     kode: 'ANNET',
     term: 'Fritekstfelt'
   }

--- a/src/begrunnelser/kontroll_begrunnelser.js
+++ b/src/begrunnelser/kontroll_begrunnelser.js
@@ -62,7 +62,7 @@ const kontroll_begrunnelser = [
   },
   {
     kode: 'MANGLENDE_REGISTRERTE_ADRESSE',
-    term: 'Person mangler registrert adresse. Den må registreres for å kunne sende brev, SED eller attest.'
+    term: 'Bruker har ingen registrert adresse.'
   },
   {
     kode: 'MANGLENDE_OPPL_ARBEIDSSTED',


### PR DESCRIPTION
Dukket opp forskjeller i skisser og faktisk verdi under testing av [MELOSYS-5094](https://jira.adeo.no/browse/MELOSYS-5094). Etter kort diskusjon med Mina kom vi frem til å ta i bruk den mer generelle feilmeldingen