### PR TITLE
5276 Nye behandlingstemaer EØS

### DIFF
--- a/src/behandlinger/behandlingstema.js
+++ b/src/behandlinger/behandlingstema.js
@@ -12,6 +12,14 @@ const behandlingstema = [
     term: 'MED: Arbeid eller selvstendig virksomhet i ett land'
   },
   {
+    kode: 'ARBEID_TJENESTEPERSON_ELLER_FLY',
+    term: 'Offentlig tjenesteperson/flyvende personell'
+  },
+  {
+    kode: 'ARBEID_KUN_NORGE',
+    term: 'Arbeid kun i Norge'
+  },
+  {
     kode: 'IKKE_YRKESAKTIV',
     term: 'MED: Ikke yrkesaktiv'
   },


### PR DESCRIPTION
https://confluence.adeo.no/pages/viewpage.action?pageId=394299697

Ny koder for EØS i forbindelse med å kunne journalføre alle saker i Melosys. ARBEID_KUN_NORGE skal dekke 11.3.a og resten av EØS-sakene som per i dag ikke kan behandles i Melosys.
