### PR TITLE
Oppdaterer tekst til REGISTRERT_UNNTAK

### DIFF
--- a/melosys-kodeverk-java/melosys-kodeverk-generator/src/test/resources/dist/kodemap.yml
+++ b/melosys-kodeverk-java/melosys-kodeverk-generator/src/test/resources/dist/kodemap.yml
@@ -85,7 +85,7 @@ behandlinger:
     - kode: IKKE_FASTSATT
       term: Ikke fastsatt
     - kode: REGISTRERT_UNNTAK
-      term: Om unntaksperioden har blitt godkjent for registrering
+      term: Unntaksperioden er godkjent
     - kode: AVSLAG_MANGLENDE_OPPL
       term: Avslått pga manglende opplysninger
     - kode: MEDLEM_I_FOLKETRYGDEN

--- a/src/behandlinger/behandlingsresultattyper.js
+++ b/src/behandlinger/behandlingsresultattyper.js
@@ -26,7 +26,7 @@ const behandlingsresultattyper = [
   },
   {
     kode: 'REGISTRERT_UNNTAK',
-    term: 'Om unntaksperioden har blitt godkjent for registrering',
+    term: 'Unntaksperioden er godkjent',
   },
   {
     kode: 'AVSLAG_MANGLENDE_OPPL',


### PR DESCRIPTION
Etter kommentar i https://jira.adeo.no/browse/MELOSYS-5195

> Teksten på behandlingsresultat REGISTRERT_UNNTAK ga lite mening, den er per nå "Om unntaksperioden har blitt godkjent for registrering". Det var teksten som tidligere sto i "kodeverk i Melosys"-lista. Har oppdatert den nå, og ny tekst skal være "Unntaksperioden er godkjent". Se Confluence: https://confluence.adeo.no/display/TEESSI/Kodeverk+i+Melosys#KodeverkiMelosys-BehandlingsResultatTyper