### PR TITLE
5348 Fjern prefiks MED: og UFM: i behandlingstema

### DIFF
--- a/src/behandlinger/behandlingstema.js
+++ b/src/behandlinger/behandlingstema.js
@@ -1,15 +1,15 @@
 const behandlingstema = [
   {
     kode: 'UTSENDT_ARBEIDSTAKER',
-    term: 'MED: Utsendt arbeidstaker / skip / direkte til artikkel 16'
+    term: 'Utsendt arbeidstaker / skip / direkte til artikkel 16'
   },
   {
     kode: 'UTSENDT_SELVSTENDIG',
-    term: 'MED: Utsendt selvstendig næringsdrivende / skip / direkte til artikkel 16'
+    term: 'Utsendt selvstendig næringsdrivende / skip / direkte til artikkel 16'
   },
   {
     kode: 'ARBEID_ETT_LAND_ØVRIG',
-    term: 'MED: Arbeid eller selvstendig virksomhet i ett land'
+    term: 'Arbeid eller selvstendig virksomhet i ett land'
   },
   {
     kode: 'ARBEID_TJENESTEPERSON_ELLER_FLY',
@@ -21,43 +21,43 @@ const behandlingstema = [
   },
   {
     kode: 'IKKE_YRKESAKTIV',
-    term: 'MED: Ikke yrkesaktiv'
+    term: 'Ikke yrkesaktiv'
   },
   {
     kode: 'ARBEID_FLERE_LAND',
-    term: 'MED: Arbeid og/eller selvstendig virksomhet i flere land'
+    term: 'Arbeid og/eller selvstendig virksomhet i flere land'
   },
   {
     kode: 'ARBEID_NORGE_BOSATT_ANNET_LAND',
-    term: 'MED: Arbeid eller selvstendig virksomhet i Norge - bosatt i et annet land'
+    term: 'Arbeid eller selvstendig virksomhet i Norge - bosatt i et annet land'
   },
   {
     kode: 'REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING',
-    term: 'UFM: Melding om utstasjonering – A009'
+    term: 'Melding om utstasjonering – A009'
   },
   {
     kode: 'REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE',
-    term: 'UFM: Melding om lovvalg – A010'
+    term: 'Melding om lovvalg – A010'
   },
   {
     kode: 'BESLUTNING_LOVVALG_NORGE',
-    term: 'MED: Beslutning om norsk lovvalg – A003'
+    term: 'Beslutning om norsk lovvalg – A003'
   },
   {
     kode: 'BESLUTNING_LOVVALG_ANNET_LAND',
-    term: 'UFM: Beslutning om lovvalg i et annet land – A003'
+    term: 'Beslutning om lovvalg i et annet land – A003'
   },
   {
     kode: 'ANMODNING_OM_UNNTAK_HOVEDREGEL',
-    term: 'UFM: Anmodning om unntak – A001'
+    term: 'Anmodning om unntak – A001'
   },
   {
     kode: 'ØVRIGE_SED_MED',
-    term: 'MED: Henvendelse eller forespørsel'
+    term: 'Henvendelse eller forespørsel'
   },
   {
     kode: 'ØVRIGE_SED_UFM',
-    term: 'UFM: Henvendelse eller forespørsel'
+    term: 'Henvendelse eller forespørsel'
   },
   {
     kode: 'FORESPØRSEL_TRYGDEMYNDIGHET',
@@ -65,7 +65,7 @@ const behandlingstema = [
   },
   {
     kode: 'TRYGDETID',
-    term: 'MED: Forespørsel om trygdetid'
+    term: 'Forespørsel om trygdetid'
   },
   {
     kode: 'ARBEID_I_UTLANDET',


### PR DESCRIPTION
De er ikke nødvendig lenger fordi vi har sakstema. 
https://jira.adeo.no/browse/MELOSYS-5348
