### PR TITLE
Fjernet behandlingstema og -typer som ikke er i bruk lenger

### DIFF
--- a/src/behandlinger/behandlingstema.js
+++ b/src/behandlinger/behandlingstema.js
@@ -8,10 +8,6 @@ const behandlingstema = [
     term: 'Utsendt selvstendig næringsdrivende / skip / direkte til artikkel 16'
   },
   {
-    kode: 'ARBEID_ETT_LAND_ØVRIG',
-    term: 'Arbeid eller selvstendig virksomhet i ett land'
-  },
-  {
     kode: 'ARBEID_TJENESTEPERSON_ELLER_FLY',
     term: 'Offentlig tjenesteperson/flyvende personell'
   },

--- a/src/behandlinger/behandlingstyper.js
+++ b/src/behandlinger/behandlingstyper.js
@@ -8,14 +8,6 @@ const behandlingstyper = [
     term: 'Førstegangsbehandling'
   },
   {
-    kode: 'SOEKNAD',
-    term: 'Søknad'
-  },
-  {
-    kode: 'SED',
-    term: 'SED'
-  },
-  {
     kode: 'NY_VURDERING',
     term: 'Ny vurdering'
   },
@@ -26,10 +18,6 @@ const behandlingstyper = [
   {
     kode: 'KLAGE',
     term: 'Klage'
-  },
-  {
-    kode: 'ANKE',
-    term: 'Anke'
   },
   {
     kode: 'ENDRET_PERIODE',


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5271
Bumper bruk av kodeverket i alle appene våre så fort det er merget og fjernet evt bruk av disse kodene

- Behandlingstema `ARBEID_ETT_LAND_ØVRIG` skal fjernes
- Behandlingstype `SØKNAD` og `SED` fjernes
- Behandlingstype `ANKE` skal fjernes fra kode