### PR TITLE
4835 Endret navn fra OFFENTLIG_ETAT til ETAT

### DIFF
--- a/src/aktoerroller.js
+++ b/src/aktoerroller.js
@@ -25,8 +25,8 @@ const aktoersroller = [
     term: 'Representant trygdeavgift'
   },
   {
-    kode: 'OFFENTLIG_ETAT',
-    term: 'Offentlig etat'
+    kode: 'ETAT',
+    term: 'Etat'
   },
   {
     kode: 'VIRKSOMHET',


### PR DESCRIPTION
Endret navn fra OFFENTLIG_ETAT til ETAT, ettersom etat er per definisjon offentlig.