### PR TITLE
5693 Lagt til ny kontrollbregunnelse for opphørt arbeidsforhold/arbeidsgiver

### DIFF
--- a/src/begrunnelser/kontroll_begrunnelser.js
+++ b/src/begrunnelser/kontroll_begrunnelser.js
@@ -89,6 +89,10 @@ const kontroll_begrunnelser = [
     term: 'Perioden er mer enn fem år!'
   },
   {
+    kode: 'OPPHØRT_ARBEIDSGIVER',
+    term: 'Arbeidsforholdet/arbeidsgiver er opphørt. Hvis arbeidsgiver har et nytt organisasjonsnummer, kan du legge inn dette i sidemenyen under Arbeidsgiver/Virksomhet - Arbeidsgiver i Norge, og starte på nytt i stegvelgeren fra Virksomhet.'
+  },
+  {
     kode: 'ATTEST_MANGLER_ARBEIDSSTED',
     term: 'Du må oppgi et arbeidssted/representant i utlandet'
   },


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5693

> 1. Saksbehandler må få et varsel med informasjon om at hen kan legge inn nytt organisasjonsnummer i sidemenyen slik at orienteringsbrevet blir sendt til riktig mottaker når nytt organisasjonsnummer finnes.
> 
> Tekst til varselet på vedtakssteget:
> 
> Arbeidsforholdet/arbeidsgiver er opphørt. Hvis arbeidsgiver har et nytt organisasjonsnummer, kan du legge inn dette i sidemenyen under Arbeidsgiver/Virksomhet - Arbeidsgiver i Norge, og starte på nytt i stegvelgeren fra Virksomhet.
> 