### PR TITLE
5752 Anmodning eller attest mottakertype

### DIFF
--- a/src/mottatteopplysningertyper.js
+++ b/src/mottatteopplysningertyper.js
@@ -22,6 +22,10 @@ const mottatteopplysningertyper = [
   {
     kode: 'SØKNAD_TRYGDEAVTALE',
     term: 'Søknad om medlemskap i folketrygden'
+  },
+  {
+    kode: 'ANMODNING_ELLER_ATTEST',
+    term: 'Anmodning eller attest'
   }
 ];
 


### PR DESCRIPTION
Det kommer en ny mottatteopplysninger-type som skal gjelde for unntaksflyten. Fag har bestemt at denne skal hete AnmodningEllerAttest og kaller derfor denne det samme.

https://jira.adeo.no/browse/MELOSYS-5752