### PR TITLE
NOJIRA: Bump Spring Boot version 2.1.6.RELEASE -> 2.2.13.RELEASE

### DIFF
--- a/melosys-kodeverk-java/melosys-kodeverk-generator/pom.xml
+++ b/melosys-kodeverk-java/melosys-kodeverk-generator/pom.xml
@@ -79,8 +79,8 @@
                     <executable>true</executable>
                     <mainClass>no.nav.melosys.Application</mainClass>
                     <arguments>
-                        <argument>melosys-kodeverk-generator/src/test/resources/dist/kodemap.yml</argument>
-                        <argument>melosys-kodeverk-generator/src/test/resources/dist/semver.txt</argument>
+                        <argument>src/test/resources/dist/kodemap.yml</argument>
+                        <argument>src/test/resources/dist/semver.txt</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/melosys-kodeverk-java/pom.xml
+++ b/melosys-kodeverk-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.2.13.RELEASE</version>
     </parent>
 
     <groupId>no.nav.melosys</groupId>


### PR DESCRIPTION
https://nav-it.slack.com/archives/C01BSCJM127/p1677679042739149

Dette var nærmeste SpringBoot versjon som ikke hadde kritiske sårbarheten i seg. Jeg ønsket ikke bruke ekstra mye tid på å oppgradere til siste versjon av Spring Boot