### PR TITLE
5986 Ny mottatteopplysningertype SØKNAD_YRKESAKTIVE_NORGE_ELLER UTENFOR_EØS

### DIFF
--- a/src/mottatteopplysningertyper.js
+++ b/src/mottatteopplysningertyper.js
@@ -24,6 +24,10 @@ const mottatteopplysningertyper = [
     term: 'Søknad om medlemskap i folketrygden'
   },
   {
+    kode: 'SØKNAD_YRKESAKTIVE_NORGE_ELLER UTENFOR_EØS',
+    term: 'Søknadsopplysninger om yrkesaktive utenfor EØS eller i Norge'
+  },
+  {
     kode: 'SØKNAD_IKKE_YRKESAKTIV',
     term: 'Søknadsopplysninger om ikke yrkesaktive innen eller utenfor EØS eller i Norge'
   },

--- a/src/mottatteopplysningertyper.js
+++ b/src/mottatteopplysningertyper.js
@@ -24,7 +24,7 @@ const mottatteopplysningertyper = [
     term: 'Søknad om medlemskap i folketrygden'
   },
   {
-    kode: 'SØKNAD_YRKESAKTIVE_NORGE_ELLER UTENFOR_EØS',
+    kode: 'SØKNAD_YRKESAKTIVE_NORGE_ELLER_UTENFOR_EØS',
     term: 'Søknadsopplysninger om yrkesaktive utenfor EØS eller i Norge'
   },
   {


### PR DESCRIPTION
 Denne skal etterhvert ta over for SØKNAD_TRYGDEAVTALE og SØKNAD_FOLKETRYGDEN


https://jira.adeo.no/browse/MELOSYS-5986

https://confluence.adeo.no/display/TEESSI/Kodeverk+i+Melosys#KodeverkiMelosys-mottatteopplysningertyper