### PR TITLE
6389 Fjerner kontrollbegrunnelser som ikke skulle eksistere

### DIFF
--- a/src/begrunnelser/kontroll_begrunnelser.js
+++ b/src/begrunnelser/kontroll_begrunnelser.js
@@ -23,14 +23,6 @@ const kontroll_begrunnelser = [
     term: 'Det finnes overlappende medlemskapsperiode i MEDL'
   },
   {
-    kode: 'OPPHOERT_OVERLAPPER_INNVILGET_PERIODE',
-    term: 'Opphørt periode overlapper med innvilget periode'
-  },
-  {
-    kode: 'OPPHOERT_OVERLAPPER_OPPHOERT_PERIODE',
-    term: 'Opphørte perioder overlapper'
-  },
-  {
     kode: 'MOTTAR_YTELSER',
     term: 'Personen mottar ytelser'
   },


### PR DESCRIPTION
Valideringen skal ikke skje i "kontroller", men i schema i frontend. Så fjernt begrunnelsene fra kodeverk