### PR TITLE
6445 Fjerner migrert kode FTRL_2_8_FORUTGÅENDE_TRYGDETID

### DIFF
--- a/src/vilkaar/vilkaar.js
+++ b/src/vilkaar/vilkaar.js
@@ -116,10 +116,6 @@ const vilkaar = [
     term: 'Er søker i arbeid på et skip registrert i en stat utenfor EØS-området?'
   },
   {
-    kode: 'FTRL_2_8_FORUTGÅENDE_TRYGDETID',
-    term: 'Har søker vært medlem i minst tre av de fem siste kalenderårene?'
-  },
-  {
     kode: 'FTRL_FORUTGÅENDE_TRYGDETID',
     term: 'Har søker vært medlem i minst tre av de fem siste kalenderårene?'
   },


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6445
Har migrert til ny kode. Fjerner den gamle fra kodeverket